### PR TITLE
[fix] Fix issue with fmt by adding fmt::streamed that force fallback to ostream<< in SimpleInput

### DIFF
--- a/widgets/form/widgets.h
+++ b/widgets/form/widgets.h
@@ -602,7 +602,7 @@ struct SimpleInput : public Widget
     if constexpr(std::is_same_v<DataT, std::string>) { return value_.has_value() ? value_.value() : ""; }
     else
     {
-      return fmt::format("{}", value_.has_value() ? value_.value() : temp_);
+      return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
     }
   }
 

--- a/widgets/form/widgets.h
+++ b/widgets/form/widgets.h
@@ -602,11 +602,11 @@ struct SimpleInput : public Widget
     if constexpr(std::is_same_v<DataT, std::string>) { return value_.has_value() ? value_.value() : ""; }
     else
     {
-      #if FMT_VERSION >= 9 * 10000
-        return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
-      #else
-        return fmt::format("{}", value_.has_value() ? value_.value() : temp_);
-      #endif
+#if FMT_VERSION >= 9 * 10000
+      return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
+#else
+      return fmt::format("{}", value_.has_value() ? value_.value() : temp_);
+#endif
     }
   }
 

--- a/widgets/form/widgets.h
+++ b/widgets/form/widgets.h
@@ -602,7 +602,11 @@ struct SimpleInput : public Widget
     if constexpr(std::is_same_v<DataT, std::string>) { return value_.has_value() ? value_.value() : ""; }
     else
     {
-      return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
+      #if FMT_VERSION >= 9 * 10000
+        return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
+      #else
+        return fmt::format("{}", value_.has_value() ? value_.value() : temp_);
+      #endif
     }
   }
 


### PR DESCRIPTION
This PR fix issues encountered with fmt in `SimpleInput` by wrapping the value with `fmt::streamed` forcing fallback to `ostream<<`.

### Patch:
```cpp
return fmt::format("{}", fmt::streamed(value_.has_value() ? value_.value() : temp_));
```

This improves compatibility with newer `fmt` versions and avoids compilation errors.
Fix issue #8 and should replace PR #9